### PR TITLE
Update to version 1.3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If you plan on using the "Specific unique" feature for this plugin, the plugin i
 ![Example image](https://i.imgur.com/Kx3ZM77.png)
 
 ### Changelog
+- **2/2/26 (1.3.5)**  
+Fix issue where a white and unique light would appear at the same time when receiving a unique drop. Fix unique light not clearing properly between raids.
  - **12/22/25 (1.3.4)**  
 Replace recoloring logic for the light above the chest to fix an issue where the light would not change colors for some users.
  - **1/1/22 (1.3.3)**  

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.coxlightcolors'
-version = '1.3.4'
+version = '1.3.5'
 sourceCompatibility = JavaVersion.VERSION_11
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/coxlightcolors/CoxLightColorsPlugin.java
+++ b/src/main/java/com/coxlightcolors/CoxLightColorsPlugin.java
@@ -182,7 +182,8 @@ public class CoxLightColorsPlugin extends Plugin implements RenderCallback
 							Color newLightColor = getUniqueGroupColor(dropName);
 							log.debug("Light object not null when special loot received by local player. Recoloring light " +
 								"based on unique group: {}", String.format("#%06x", newLightColor.getRGB() & 0x00FFFFFF));
-							clientThread.invoke(() -> spawnFakeLightObject(lightObject.getLocalLocation(), newLightColor));
+							clearFakeLightObject();
+							clientThread.invoke(() -> fakeLightObject = spawnFakeLightObject(lightObject.getLocalLocation(), newLightColor));
 						}
 						else
 						{


### PR DESCRIPTION
- Fix an issue where a white light would spawn alongside the unique light when getting a rare drop
- Fix an issue where the unique light wouldn't get cleared